### PR TITLE
Trim whitespace to enable formatting by space

### DIFF
--- a/src/main/java/jp/co/flect/util/ResourceGen.java
+++ b/src/main/java/jp/co/flect/util/ResourceGen.java
@@ -84,8 +84,8 @@ public class ResourceGen {
 			if (idx == -1) {
 				return;
 			}
-			String key = s.substring(0, idx);
-			String value = s.substring(idx+1);
+			String key = s.substring(0, idx).trim();
+			String value = s.substring(idx+1).trim();
 			String lang = "";
 			if (key.endsWith("]")) {
 				idx = key.indexOf('[');


### PR DESCRIPTION
Current ResourceGen not allowed to set format like below.

```
some.key     = SomeValue
some.key[ja] = なんかの値
```

This PR enables those align by trimming whitespaces
